### PR TITLE
add support for functions that return constants

### DIFF
--- a/autodiffcc/core.py
+++ b/autodiffcc/core.py
@@ -516,7 +516,7 @@ def differentiate(base_func):
 
         # if base_func returns a scalar and not an AD object
         if np.isscalar(result):
-            return AD(result, der=0)
+            return AD(result, der=0).der
         # if base_func is a scalar function, return 1-D flat derivative (combining multiple vector-valued inputs)
         if isinstance(result, AD):
             return result.der.flatten()
@@ -526,8 +526,9 @@ def differentiate(base_func):
         final_der = []
         for ad_obj in result:
             if not isinstance(ad_obj, AD):
-                ad_obj = AD(ad_obj, der=np.zeros((1, n_vars_inner)))
-            final_der.append(ad_obj.der.flatten())
+                final_der.append(np.zeros(n_vars_inner))
+            else:
+                final_der.append(ad_obj.der.flatten())
 
         return np.array(final_der)
 

--- a/autodiffcc/core.py
+++ b/autodiffcc/core.py
@@ -514,14 +514,19 @@ def differentiate(base_func):
         # run base_func on input values now keeping track of derivative
         result = base_func(*variables)
 
+        # if base_func returns a scalar and not an AD object
+        if np.isscalar(result):
+            return AD(result, der=0)
         # if base_func is a scalar function, return 1-D flat derivative (combining multiple vector-valued inputs)
-        if type(result) == AD:
+        if isinstance(result, AD):
             return result.der.flatten()
-        
+
         # if base_func is vector function, return 2-D Jacobian where each row is f1, f2, ...
         n_fn_dim = len(result)
         final_der = []
         for ad_obj in result:
+            if not isinstance(ad_obj, AD):
+                ad_obj = AD(ad_obj, der=np.zeros((1, n_vars_inner)))
             final_der.append(ad_obj.der.flatten())
 
         return np.array(final_der)

--- a/autodiffcc/root.py
+++ b/autodiffcc/root.py
@@ -24,7 +24,24 @@ def _norm(vector):
 
 
 def _newton_raphson(function, values, threshold, max_iter):
-    """#TODO
+    """Returns a root found starting from values or raised Exception if none are found
+
+    INPUTS
+    =======
+    function: a function using ADmath methods
+    values: the starting point for Newton-Raphson
+    threshold: the minimum threshold for finding a root
+    max_iter: maximum number of iterations that algorithm will look for before quitting
+        - in case method does not converge
+
+    RETURNS
+    ========
+    A root of function found starting from values or raised Exception if none are found
+
+    EXAMPLES
+    =========
+    >>> _newton_raphson(lambda x: x, 3, 1e-8, 2000)
+    0.
     """
     jacobian = differentiate(function)
     output_shape = len(np.array(function(*values)).flatten())
@@ -55,8 +72,8 @@ def find_root(function, method, start_values, threshold=1e-8, max_iter=2000):
     INPUTS
     =======
     function: a function using ADmath methods
-    start: the starting point of the root-finding method (scalar or vector)
     method: the method to do root-finding   #TODO: add list of possible methods
+    start_values: the starting point of the root-finding method (scalar or vector)
     threshold: the minimum threshold for finding a root
     max_iter: maximum number of iterations that algorithm will look for before quitting
         - in case method does not converge
@@ -67,9 +84,8 @@ def find_root(function, method, start_values, threshold=1e-8, max_iter=2000):
 
     EXAMPLES
     =========
-    >>> x = AD(val = 3, der = 1)
-    >>> 2 ** x
-    (8.0, 5.54517744)
+    >>> find_root(lambda x: x+2, 'newton', 2)
+    -2.
     """
     # process variable inputs
     signature = inspect.signature(function).parameters.keys()

--- a/autodiffcc/root.py
+++ b/autodiffcc/root.py
@@ -27,10 +27,11 @@ def _newton_raphson(function, values, threshold, max_iter):
     """#TODO
     """
     jacobian = differentiate(function)
+    output_shape = len(np.array(function(*values)).flatten())
 
     for i in range(max_iter):
         flat_variables = values.flatten()
-        if len(flat_variables) == 1:
+        if len(flat_variables) == 1 and output_shape == 1:
             flat_variables = flat_variables - function(*values) / jacobian(*values)
         else:
             flat_variables = flat_variables - np.matmul(np.linalg.pinv(jacobian(*values)), function(*values))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -308,4 +308,8 @@ def test_differentiate_scalar_function_0_der():
         return 2
     assert np.isclose(differentiate(f)(3), 0)
 
+def test_differentiate_vector_function_0_der():
+    def f(x, y):
+        return 2, 3
+    assert np.allclose(differentiate(f)(3,1), 0)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -303,4 +303,9 @@ def test_differentiate_args_issues():
     with pytest.raises(KeyError):
         dfdx(x=2, y=3, z=3)
 
+def test_differentiate_scalar_function_0_der():
+    def f(x):
+        return 2
+    assert np.isclose(differentiate(f)(3), 0)
+
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -25,19 +25,6 @@ def test_root_bad_inputs():
     # Incorrect number of variables
     with pytest.raises(KeyError, match="Incorrect number of variables passed in start_values."):
         find_root(function=f2var, method='newton', start_values=[1,2,3])
-    
-# jacobian = differentiate(function)
-
-# for i in range(max_iter):
-#     flat_variables = values.flatten()
-#     if len(flat_variables) == 1:
-#         flat_variables = flat_variables - function(*values) / jacobian(*values)
-#     else:
-#         flat_variables = flat_variables - np.matmul(np.linalg.pinv(jacobian(*values)), function(*values))
-#     values = flat_variables.reshape(values.shape)
-#     if _norm(function(*values)) < threshold:
-#         return values
-# raise Exception("Newton-Raphson did not converge, try increasing max_iter.")
 
 def test_newton_raphson_scalar():
     def f1var(x):


### PR DESCRIPTION
Our old `core.py` didn't know how to differentiate functions that looked like this:
def f(x):
.    return 3
